### PR TITLE
Analyze webdriver property

### DIFF
--- a/antibot/analyzer/analyzer.go
+++ b/antibot/analyzer/analyzer.go
@@ -8,6 +8,7 @@ type ClientProperties struct {
 	Languages []string `json:"languages"`
 	Plugins   []string `json:"plugins"`
 	Window    []string `json:"custom_window"`
+	Webdriver bool     `json:"webdriver"`
 }
 
 type Analyzer struct{}
@@ -20,9 +21,17 @@ func NewAnalyzer() *Analyzer {
 // Returns false if properties are invalid, or true otherwise
 func (a *Analyzer) AnalyzeProperties(properties ClientProperties) bool {
 	// TODO: Add more checks here
+
 	return a.analyzeLanguages(properties.Languages) &&
 		a.analyzePlugins(properties.Plugins) &&
-		a.analyzeWindow(properties.Window)
+		a.analyzeWindow(properties.Window) &&
+		a.analyzeWebdriver(properties.Webdriver)
+}
+
+// analyzeWebdriver checks navigator.webdriver property value
+// If navigator.webdriver == True - possibly bot
+func (a *Analyzer) analyzeWebdriver(webdriver bool) bool {
+	return !webdriver
 }
 
 // analyzeLanguages checks available languages


### PR DESCRIPTION
> In order to automate Chrome headless, a new property webdriver is added to the navigator object. Thus, by testing if the property is present it is possible to detect Chrome headless.

Goes with: https://github.com/antibot-dev-team/antibot-agent/pull/7