### PR TITLE
Check if window.chrome property is present on Chrome and Opera

### DIFF
--- a/antibot/analyzer/analyzer.go
+++ b/antibot/analyzer/analyzer.go
@@ -1,8 +1,6 @@
 package analyzer
 
-import (
-	"strings"
-)
+import "strings"
 
 const chromeDriverPrefix = "cdc_"
 
@@ -73,8 +71,10 @@ func (a *Analyzer) analyzeWindow(window []string) bool {
 func (a *Analyzer) analyzeWindowChrome(hasWindowChrome bool, ua string) bool {
 	// TODO: check if window.chrome is present in Chrome on iOS. If so, check UA for "CriOS" substring.
 
-	isChromeOrOpera := strings.Contains(ua, "Chrome") || strings.Contains(ua, "Chromium")
-	isChromeOrOpera = isChromeOrOpera || strings.Contains(ua, "Opera") || strings.Contains(ua, "OPR")
+	ua = strings.ToLower(ua)
+
+	isChromeOrOpera := strings.Contains(ua, "chrome") || strings.Contains(ua, "chromium")
+	isChromeOrOpera = isChromeOrOpera || strings.Contains(ua, "opera") || strings.Contains(ua, "opr")
 
 	return !isChromeOrOpera || hasWindowChrome
 }

--- a/antibot/analyzer/analyzer.go
+++ b/antibot/analyzer/analyzer.go
@@ -7,10 +7,11 @@ import (
 const chromeDriverPrefix = "cdc_"
 
 type ClientProperties struct {
-	Languages []string `json:"languages"`
-	Plugins   []string `json:"plugins"`
-	Window    []string `json:"custom_window"`
-	UserAgent string   `json:"ua"`
+	Languages       []string `json:"languages"`
+	Plugins         []string `json:"plugins"`
+	Window          []string `json:"custom_window"`
+	UserAgent       string   `json:"ua"`
+	HasWindowChrome bool     `json:"has_window_chrome"`
 }
 
 type Analyzer struct{}
@@ -25,7 +26,8 @@ func (a *Analyzer) AnalyzeProperties(properties ClientProperties) bool {
 	// TODO: Add more checks here
 	return a.analyzeLanguages(properties.Languages) &&
 		a.analyzePlugins(properties.Plugins, properties.UserAgent) &&
-		a.analyzeWindow(properties.Window)
+		a.analyzeWindow(properties.Window) &&
+		a.analyzeWindowChrome(properties.HasWindowChrome, properties.UserAgent)
 }
 
 // analyzeLanguages checks available languages
@@ -55,4 +57,15 @@ func (a *Analyzer) analyzeWindow(window []string) bool {
 	}
 
 	return true
+}
+
+// analyzeWindowChrome checks if window.chrome is not present but client's browser is Chrome, Chromium or Opera
+// While window.chrome is available in vanilla mode, it’s not available in headless mode.
+func (a *Analyzer) analyzeWindowChrome(hasWindowChrome bool, ua string) bool {
+	// TODO: check if window.chrome is present in Chrome on iOS. If so, check UA for "CriOS" substring.
+
+	isChromeOrOpera := strings.Contains(ua, "Chrome") || strings.Contains(ua, "Chromium")
+	isChromeOrOpera = isChromeOrOpera || strings.Contains(ua, "Opera") || strings.Contains(ua, "OPR")
+
+	return !isChromeOrOpera || hasWindowChrome
 }


### PR DESCRIPTION
> window.chrome is an object that seems to provide features to Chrome extension developers. While it is available in vanilla mode, it’s not available in headless mode.

This branch is based on [fix-firefox](https://github.com/antibot-dev-team/antibot-backend/pull/7) because for this check user agent should be accessible to analyzer, and on [fix-firefox](https://github.com/antibot-dev-team/antibot-backend/pull/7) it is.